### PR TITLE
Fix typo in color2.yaml

### DIFF
--- a/examples/raw/color2.yaml
+++ b/examples/raw/color2.yaml
@@ -1,5 +1,5 @@
 Image: "docker.io/mmushad/simple-webapp-color:latest"
-Name: "colors1"
+Name: "colors2"
 Env:
   APP_COLOR: "pink"
   tree: "trunk"


### PR DESCRIPTION
This commit fixes a typo where the yaml in color2.yaml
specifies a container with the name "colors1" instead of
"colors2"

Signed-off-by: Joseph Sawaya <jsawaya@redhat.com>